### PR TITLE
Fix logspam (in debug Unity player) due to incorrect usage of Unity APIs

### DIFF
--- a/Toolbar/Internal/Toolbar/ToolbarManager.cs
+++ b/Toolbar/Internal/Toolbar/ToolbarManager.cs
@@ -32,7 +32,7 @@ using UnityEngine;
 namespace Toolbar {
 	[KSPAddonFixed(KSPAddon.Startup.EveryScene, true, typeof(ToolbarManager))]
 	public partial class ToolbarManager : MonoBehaviour, IToolbarManager {
-		private static readonly string SETTINGS_FILE = KSPUtil.ApplicationRootPath + "GameData/toolbar-settings.dat";
+		private static string SETTINGS_FILE = "GameData/toolbar-settings.dat"; // Full path initialized in Awake()
 		internal const string FORUM_THREAD_URL = "https://forum.kerbalspaceprogram.com/index.php?/topic/161857-131-toolbar-continued";
 		internal const string NAMESPACE_INTERNAL = "__TOOLBAR_INTERNAL";
 
@@ -67,6 +67,16 @@ namespace Toolbar {
 
 		internal ToolbarManager() {
 			Log.trace("ToolbarManager()");
+		}
+
+		private void Awake()
+		{
+			//
+			// Perform any initializations here which require calling into the Unity APIs.
+			// Unity spec does not allow calling Unity APIs from field initializers or constructors.
+			//
+
+			SETTINGS_FILE = KSPUtil.ApplicationRootPath + SETTINGS_FILE;
 
 			if (Instance == null) {
 				Instance = this;


### PR DESCRIPTION

Unity APIs are not allowed to be called in field initializers or class constructors. Initialize your class in Awake() or Start() instead.

----

Tested with several mods which use the Toolbar and it seems to be working fine in both the released Unity player shipped with KSP 1.5 and the debug Unity player. No more exceptions in the debug player.