### PR TITLE
Fix fuzzy textures in GameDatabase

### DIFF
--- a/Toolbar/Internal/Toolbar/Button.cs
+++ b/Toolbar/Internal/Toolbar/Button.cs
@@ -93,12 +93,7 @@ namespace Toolbar {
                 Log.info("Texture");
 				if ((texture_ == null) && (command.TexturePath != null)) {
 					try {
-                        if (! Utils.TextureExists(Utils.TexPathname(command.TexturePath)))
-                            texture_ = GameDatabase.Instance.GetTexture(command.TexturePath, false);
-                        else
-                            texture_ = Utils.GetTexture(command.TexturePath, false);
-                        //if (texture_ == null)
-                        //    texture_ = GameDatabase.Instance.GetTexture(command.TexturePath, false);
+                        texture_ = Utils.GetTexture(command.TexturePath, false);
                         if (texture_ != null) {
 							if ((texture_.width > MAX_TEX_WIDTH) || (texture_.height > MAX_TEX_HEIGHT)) {
 								Log.error("button texture exceeds {0}x{1} pixels, ignoring texture: {2}", MAX_TEX_WIDTH, MAX_TEX_HEIGHT, command.FullId);

--- a/Toolbar/Internal/Utils.cs
+++ b/Toolbar/Internal/Utils.cs
@@ -176,10 +176,14 @@ namespace Toolbar {
             return s;
         }
 
-        internal static Texture2D GetTexture(string path, bool b)
+        internal static Texture2D GetTexture(string path, bool asNormalMap)
         {
+            // ask unBlur to look for the texture in GameDatabase, remove mipmaps if necessary, and return it
+            Texture2D tex = UnBlur.UnBlur.Instance?.GetTexture(path, asNormalMap);
+            if (tex != null) return tex;
 
-            Texture2D tex = new Texture2D(16, 16, TextureFormat.ARGB32, false);
+            // texture not found in GameDatabase
+            tex = new Texture2D(16, 16, TextureFormat.ARGB32, false);
 
             if (LoadImageFromFile(ref tex, TexPathname(path)))
                 return tex;

--- a/Toolbar/Internal/Utils.cs
+++ b/Toolbar/Internal/Utils.cs
@@ -114,18 +114,14 @@ namespace Toolbar {
             }
             return blnReturn;
         }
-        internal static bool TextureExists(string fileNamePath)
+        internal static bool TextureExists(string texturePath)
         {
-            string path = fileNamePath;
-            if (!System.IO.File.Exists(fileNamePath))
-            {
-                // Look for the file with an appended suffix.
-                for (int i = 0; i < imgSuffixes.Length; i++)
-
-                    if (System.IO.File.Exists(fileNamePath + imgSuffixes[i]))
-                        return true;
-
-            }
+            if (GameDatabase.Instance.ExistsTexture(texturePath))
+                return true;
+            string fileNamePath = TexPathname(texturePath);
+            for (int i = 0; i < imgSuffixes.Length; i++)
+                if (System.IO.File.Exists(fileNamePath + imgSuffixes[i]))
+                    return true;
             return false;
         }
         internal static string TexPathname(string path)

--- a/Toolbar/Internal/Utils.cs
+++ b/Toolbar/Internal/Utils.cs
@@ -187,6 +187,7 @@ namespace Toolbar {
 
             if (LoadImageFromFile(ref tex, TexPathname(path)))
                 return tex;
+            UnityEngine.Object.Destroy(tex);
             return null;
         }
     }

--- a/Toolbar/Internal/Utils.cs
+++ b/Toolbar/Internal/Utils.cs
@@ -58,10 +58,11 @@ namespace Toolbar {
         // easier to specify different cases than to change case to lower.  This will fail on MacOS and Linux
         // if a suffix has mixed case
         static string[] imgSuffixes = new string[] { ".png", ".jpg", ".gif", ".PNG", ".JPG", ".GIF", ".dds", ".DDS" };
-        static Boolean LoadImageFromFile(ref Texture2D tex, String fileNamePath)
+        static Boolean LoadImageFromFile(out Texture2D tex, String fileNamePath)
         {
 
             Boolean blnReturn = false;
+            tex = null;
             bool dds = false;
             try
             {
@@ -110,7 +111,10 @@ namespace Toolbar {
                                 tex = LoadTextureDXT(bytes, tf);
                         }
                         else
+                        {
+                            tex = new Texture2D(16, 16, TextureFormat.ARGB32, false);
                             tex.LoadImage(System.IO.File.ReadAllBytes(path));
+                        }
                         blnReturn = true;
                     }
                     catch (Exception ex)
@@ -183,12 +187,8 @@ namespace Toolbar {
             if (tex != null) return tex;
 
             // texture not found in GameDatabase
-            tex = new Texture2D(16, 16, TextureFormat.ARGB32, false);
-
-            if (LoadImageFromFile(ref tex, TexPathname(path)))
-                return tex;
-            UnityEngine.Object.Destroy(tex);
-            return null;
+            LoadImageFromFile(out tex, TexPathname(path));
+            return tex;
         }
     }
 }

--- a/Toolbar/Properties/AssemblyInfo.cs
+++ b/Toolbar/Properties/AssemblyInfo.cs
@@ -38,3 +38,4 @@ using System.Runtime.InteropServices;
 [assembly: KSPAssembly("Toolbar", 1, 0)]
 //[assembly: KSPAssemblyDependency("ClickThroughBlocker", 1, 0)]
 [assembly: KSPAssemblyDependency("ClickThroughBlocker", 1, 7, 0)]
+[assembly: KSPAssemblyDependency("unBlur", 0, 3)]

--- a/Toolbar/Properties/AssemblyInfo.cs
+++ b/Toolbar/Properties/AssemblyInfo.cs
@@ -38,4 +38,4 @@ using System.Runtime.InteropServices;
 [assembly: KSPAssembly("Toolbar", 1, 0)]
 //[assembly: KSPAssemblyDependency("ClickThroughBlocker", 1, 0)]
 [assembly: KSPAssemblyDependency("ClickThroughBlocker", 1, 7, 0)]
-[assembly: KSPAssemblyDependency("unBlur", 0, 3)]
+[assembly: KSPAssemblyDependency("unBlur", 0, 4)]

--- a/Toolbar/Toolbar.csproj
+++ b/Toolbar/Toolbar.csproj
@@ -142,7 +142,7 @@
       <HintPath>R:\KSP_1.6.1_dev\KSP_x64_Data\Managed\UnityEngine.UI.dll</HintPath>
     </Reference>
     <Reference Include="unBlur">
-      <HintPath>R:\KSP_1.6.1_dev\GameData\unBlur.0.3.0.dll</HintPath>
+      <HintPath>R:\KSP_1.6.1_dev\GameData\unBlur.0.4.0.dll</HintPath>
     </Reference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/Toolbar/Toolbar.csproj
+++ b/Toolbar/Toolbar.csproj
@@ -141,6 +141,9 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>R:\KSP_1.6.1_dev\KSP_x64_Data\Managed\UnityEngine.UI.dll</HintPath>
     </Reference>
+    <Reference Include="unBlur">
+      <HintPath>R:\KSP_1.6.1_dev\GameData\unBlur.0.3.0.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>


### PR DESCRIPTION
GameDatabase has all textures that haven't been hidden from it (by putting images in `PluginData`).
Fix the fuzzy textures in GameDatabase once, and use that henceforth, instead of reading from file at every scene change, with texture discarded without proper destruction afterwards.

`LoadImageFromFile()` retained for textures that have been deliberately hidden in `PluginData` folders. This approach should now be discouraged as it still suffers the abovementioned pitfalls.

Avoid creating blank texture unnecessarily in `GetTexture()`.

Use unBlur's `LoadDDS` instead: has DXT1, 3 & 5 support, uses pure `BinaryReader` approach so no juggling or copying of `byte[]`s, and might as well conserve code since the dependency also provides same function.

Fix #13 regression introduced by 0fc6d5b6fc19445f2563e6376062dcfca5e0c588
