### PR TITLE
Fixes to folder icons behavior

### DIFF
--- a/Toolbar/Internal/Toolbar/Toolbar.cs
+++ b/Toolbar/Internal/Toolbar/Toolbar.cs
@@ -1337,7 +1337,7 @@ namespace Toolbar
 
         private bool textureExists(string texturePath)
         {
-            return Utils.TextureFileExists(texturePath);
+            return Utils.TextureFileExists(Utils.TexPathname(texturePath));
         }
 
         internal void saveSettings(ConfigNode toolbarNode)

--- a/Toolbar/Internal/Toolbar/Toolbar.cs
+++ b/Toolbar/Internal/Toolbar/Toolbar.cs
@@ -1781,6 +1781,7 @@ namespace Toolbar
                         newSavedFolderSettings.Add(entry.Key, new FolderSettings()
                         {
                             toolTip = savedFolderSettings[entry.Key].toolTip,
+                            texturePath = savedFolderSettings[entry.Key].texturePath,
                             buttons = folderButtonIds
                         });
                     }


### PR DESCRIPTION
Related to #18

On loading settings, code was checking wrong file-path for texture.
And when dragging buttons into folder, code for saving folder's icon been forgotten.