### PR TITLE
Fix #30

### DIFF
--- a/Toolbar/Internal/Utils.cs
+++ b/Toolbar/Internal/Utils.cs
@@ -58,112 +58,94 @@ namespace Toolbar
             }
         }
 
+        /// <summary>
+        /// Length of a DDS file's image header.
+        /// </summary>
+        const int DDS_HEADER_SIZE = 128;
 
-        //
-        // The following function was initially copied from @JPLRepo's AmpYear mod, which is covered by the GPL, as is this mod
-        //
-        // This function will attempt to load either a PNG or a JPG from the specified path.  
-        // It first checks to see if the actual file is there, if not, it then looks for either a PNG or a JPG
-        //
-        // easier to specify different cases than to change case to lower.  This will fail on MacOS and Linux
-        // if a suffix has mixed case
-        static string[] imgSuffixes = new string[] { ".png", ".jpg", ".gif", ".PNG", ".JPG", ".GIF", ".dds", ".DDS" };
-        static Boolean LoadImageFromFile(ref Texture2D tex, String fileNamePath)
+        /// <summary>
+        /// Loads an image from the specified filepath.
+        /// </summary>
+        /// <remarks>If the specified path doesn't exist, this function will fail after printing a log message.</remarks>
+        /// <param name="texture">Ref of a <see cref="Texture2D"/> object to store the loaded image in.</param>
+        /// <param name="path">The path to the target image file, including extension.</param>
+        /// <returns><list type="table">
+        /// <item><term>true</term><description>Successfully loaded the image file specified by <paramref name="path"/>, and <paramref name="texture"/> now contains its contents.</description></item>
+        /// <item><term>false</term><description>The image file specified by <paramref name="path"/> doesn't exist, and <paramref name="texture"/> wasn't modified.</description></item>
+        /// </list></returns>
+        static bool LoadImageFromFile(ref Texture2D texture, string path)
         {
-
-            Boolean blnReturn = false;
-            bool isDDS = false;
-            try
+            if (!System.IO.File.Exists(path))
             {
-                string path = fileNamePath;
-                if (!System.IO.File.Exists(fileNamePath))
-                {
-                    // Look for the file with an appended suffix.
-                    for (int i = 0; i < imgSuffixes.Length; i++)
+                Log.error($"! You're missing a required image file:  '{path}'");
+                Log.error("^ To fix this issue, reinstall the mod specified by the above path.");
+                return false; //< short circuit
+            }
 
-                        if (System.IO.File.Exists(fileNamePath + imgSuffixes[i]))
-                        {
-                            path = fileNamePath + imgSuffixes[i];
-                            isDDS = imgSuffixes[i] == ".dds" || imgSuffixes[i] == ".DDS";
-                            break;
-                        }
-                }
+            if (path.EndsWith("dds", StringComparison.OrdinalIgnoreCase))
+            {   // Handle DDS image formats:
+                byte[] bytes = System.IO.File.ReadAllBytes(path);
+                TextureFormat texFmt = TextureFormat.Alpha8;
 
-                //File Exists check
-                if (System.IO.File.Exists(path))
+                // Validate the DDS header
+                using (System.IO.BinaryReader br = new System.IO.BinaryReader(new System.IO.MemoryStream(bytes)))
                 {
-                    try
+                    // DDS FORMAT SRC: https://docs.microsoft.com/en-us/windows/win32/direct3ddds/dx-graphics-dds-pguide#common-dds-file-resource-formats-and-associated-header-content
+                    uint magic = br.ReadUInt32();
+                    if (magic != DDSValues.uintMagic) // (542327876u)
                     {
-                        if (isDDS)
-                        {
-                            byte[] bytes = System.IO.File.ReadAllBytes(path);
-
-                            BinaryReader binaryReader = new BinaryReader(new MemoryStream(bytes));
-                            uint num = binaryReader.ReadUInt32();
-
-                            if (num != DDSValues.uintMagic)
-                            {
-                                UnityEngine.Debug.LogError("DDS: File is not a DDS format file!");
-                                return false;
-                            }
-                            DDSHeader ddSHeader = new DDSHeader(binaryReader);
-
-                            TextureFormat tf = TextureFormat.Alpha8;
-                            if (ddSHeader.ddspf.dwFourCC == DDSValues.uintDXT1)
-                                tf = TextureFormat.DXT1;
-                            if (ddSHeader.ddspf.dwFourCC == DDSValues.uintDXT5)
-                                tf = TextureFormat.DXT5;
-                            if (tf == TextureFormat.Alpha8)
-                                return false;
-
-
-                            tex = LoadTextureDXT(bytes, tf);
-                        }
-                        else
-                            tex.LoadImage(System.IO.File.ReadAllBytes(path));
-                        blnReturn = true;
+                        Log.error($"! Invalid DDS Image:  '{path}'  (Magic number is '{magic}', expected '{DDSValues.uintMagic}')");
+                        Log.error("^ To fix this issue, reinstall the mod specified by the above path, and/or contact the mod author.");
+                        return false;
                     }
-                    catch (Exception ex)
+
+                    switch (new DDSHeader(br).ddspf.dwFourCC)
                     {
-                        Log.error("Failed to load the texture:" + path);
-                        Log.error(ex.Message);
+                    case 827611204u: //< "DXT1" as an unsigned integral
+                        texFmt = TextureFormat.DXT1;
+                        break;
+                    case 894720068u: //< "DXT5" as an unsigned integral
+                        texFmt = TextureFormat.DXT5;
+                        break;
+                    default:
+                        Log.error($"! Invalid DDS Image:  '{path}'  (Invalid File Header)");
+                        Log.error("^ To fix this issue, reinstall the mod specified by the above path, and/or contact the mod author.");
+                        return false;
                     }
-                }
-                else
+
+                    if (bytes[4] != 124)
+                    {
+                        Log.error($"! Invalid DDS Image:  '{path}'  (Byte[4] is '{bytes[4]}', expected '124')");
+                        Log.error("^ To fix this issue, reinstall the mod specified by the above path, and/or contact the mod author.");
+                        return false;
+                    }
+                } // if we reached this point, the DDS image is probably valid.
+
+                try
                 {
-                    Log.error("Cannot find texture to load:" + fileNamePath);
+                    // calculate the image dimensions
+                    int height = bytes[13] * 256 + bytes[12];
+                    int width = bytes[17] * 256 + bytes[16];
+
+                    // retrieve the image bytes
+                    byte[] dxtBytes = new byte[bytes.Length - DDS_HEADER_SIZE];
+                    Buffer.BlockCopy(bytes, DDS_HEADER_SIZE, dxtBytes, 0, bytes.Length - DDS_HEADER_SIZE);
+
+                    // load the texture
+                    texture = new Texture2D(width, height, texFmt, false);
+                    texture.LoadRawTextureData(dxtBytes);
+                    texture.Apply();
+                }
+                catch (Exception ex)
+                {
+                    Log.error($"! Invalid DDS Image:  '{path}'  (Exception was thrown during read operation: '{ex.Message}')");
+                    Log.error("^ To fix this issue, reinstall the mod specified by the above path, and/or contact the mod author.");
                 }
             }
-            catch (Exception ex)
-            {
-                Log.error("Failed to load (are you missing a file):" + fileNamePath);
-                Log.error(ex.Message);
-            }
-            return blnReturn;
+            else texture.LoadImage(System.IO.File.ReadAllBytes(path));
+
+            return true;
         }
-        public static Texture2D LoadTextureDXT(byte[] ddsBytes, TextureFormat textureFormat)
-        {
-            if (textureFormat != TextureFormat.DXT1 && textureFormat != TextureFormat.DXT5)
-                throw new Exception("Invalid TextureFormat. Only DXT1 and DXT5 formats are supported by this method.");
-
-            byte ddsSizeCheck = ddsBytes[4];
-            if (ddsSizeCheck != 124)
-                throw new Exception("Invalid DDS DXTn texture. Unable to read");  //this header byte should be 124 for DDS image files
-
-            int height = ddsBytes[13] * 256 + ddsBytes[12];
-            int width = ddsBytes[17] * 256 + ddsBytes[16];
-
-            int DDS_HEADER_SIZE = 128;
-            byte[] dxtBytes = new byte[ddsBytes.Length - DDS_HEADER_SIZE];
-            Buffer.BlockCopy(ddsBytes, DDS_HEADER_SIZE, dxtBytes, 0, ddsBytes.Length - DDS_HEADER_SIZE);
-
-            Texture2D texture = new Texture2D(width, height, textureFormat, false);
-            texture.LoadRawTextureData(dxtBytes);
-            texture.Apply();
-
-            return (texture);
-        }
-
         internal static Texture2D GetTexture(string texturePath)
         {
             Texture2D tmptexture = null;
@@ -192,20 +174,11 @@ namespace Toolbar
 
         internal static bool TextureFileExists(string fileNamePath)
         {
-            if (!System.IO.File.Exists(fileNamePath))
-            {
-                // Look for the file with an appended suffix.
-                for (int i = 0; i < imgSuffixes.Length; i++)
-
-                    if (System.IO.File.Exists(fileNamePath + imgSuffixes[i]))
-                        return true;
-
-            }
-            return false;
+            return System.IO.File.Exists(fileNamePath); //< we aren't modifying the texture path here, so no need to resolve the path - see TexPathname
         }
 
         static String rootPath;
-        static public String RootPath {  get { return rootPath; } }
+        static public String RootPath { get { return rootPath; } }
 
 
         internal static void InitRootPath()
@@ -214,14 +187,49 @@ namespace Toolbar
             rootPath = s.Substring(0, s.IndexOf("GameData"));
         }
 
+        static readonly string[] recognizedImgFileExtensions = new string[] { "png", "jpg", "gif", "dds" };
 
-        internal static string TexPathname(string path)
+        /// <summary>
+        /// Attempts to resolve the given filepath by searching for files with similar extensions.
+        /// </summary>
+        /// <param name="fullPath">The input filepath to resolve. If the file specified by the path already exists, it is returned unmodified; Case-sensitive filesystem handling is subject to the implementation of <see cref="System.IO.File.Exists(string)"/>.
+        /// <br/>The immediate parent directory of this file is the root directory during the search.</param>
+        /// <param name="sCompareType">The <see cref="StringComparison"/> type to use when matching filenames.</param>
+        /// <param name="fSearchType">Determines the search method used when calling <see cref="System.IO.Directory.EnumerateFiles(string, string, SearchOption)"/></param>
+        /// <returns>If the search was successful, this is the resolved path. If the search was unsuccessful, this is <paramref name="fullPath"/>.</returns>
+        internal static string ResolveTexPathname(string fullPath, StringComparison sCompareType = StringComparison.OrdinalIgnoreCase, SearchOption fSearchType = SearchOption.TopDirectoryOnly)
+        {
+            if (fullPath.Length < 1 || System.IO.File.Exists(fullPath))
+                return fullPath; //< short circuit
+
+            int sepPos;
+            string ext;
+            for (var enumerator = System.IO.Directory.EnumerateFiles(Path.GetDirectoryName(fullPath), Path.GetFileNameWithoutExtension(fullPath) + ".*", fSearchType).GetEnumerator(); enumerator.MoveNext();)
+            {
+                sepPos = enumerator.Current.LastIndexOf('.');
+                ext = sepPos == -1 ? "" : enumerator.Current.Substring(sepPos + 1);
+                if (ext.Length > 0 && recognizedImgFileExtensions.Any(recognizedExt => recognizedExt.Equals(ext, sCompareType)))
+                {
+                    return enumerator.Current;
+                }
+            }
+
+            Log.warn($"[! MISSING FILE !]:  \"{fullPath}\"");
+            return fullPath;
+        }
+
+        internal static string TexPathname(string path, bool resolvePath = true)
         {
             //Debug.Log("TexPathname, GetExecutingAssembly: " + Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location));
             //Debug.Log("TexPathname, ApplicationRootPath: " + KSPUtil.ApplicationRootPath);
             //return  KSPUtil.ApplicationRootPath + "GameData/" + path;
 
-            return RootPath + "GameData/" + path;
+            string fullpath = RootPath + "GameData/" + path;
+
+            if (resolvePath) // fallback to checking each extension type
+                return ResolveTexPathname(fullpath, StringComparison.OrdinalIgnoreCase, SearchOption.TopDirectoryOnly);
+
+            return fullpath;
         }
 
         internal static Texture2D GetTextureFromFile(string path, bool b)


### PR DESCRIPTION
Completely rewrote the image loading and path resolution functions used by `Utils.cs`   
Upgraded the `.csproj` project files locally *(this is not included in the PR)* to use .NET Framework 4.8 because 4.5 is deprecated.  

Tested on KSP version:  
![image](https://user-images.githubusercontent.com/1927798/167023683-8a77c0e4-f0d9-4ba5-b0c3-7e4d260a9429.png)
- Windows 10 Enterprise LTSC 2019 (Version `21H2` Build `19044.1566`)
- Kerbal Space Program x64 (Steam)
- Other mods installed during testing:
  - Clickthrough Blocker
  - Toolbar Controller
  - Development DLL I threw together that uses Toolbar Controller to register a toolbar with null image files.  

Example of this working with the changes from this commit:  
![image](https://user-images.githubusercontent.com/1927798/167023424-d81380cd-c575-4767-915b-3b627b63ad08.png)